### PR TITLE
Add ExperimentInputSpec.computed_features for MultiIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to **scythe-engine** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - Unreleased
+## [1.2.0] - Unreleased
+
+### Added
+
+- `computed_features` property on `ExperimentInputSpec` for attaching derived
+  scalar index levels to the `MultiIndex` without defining them as Pydantic
+  fields. Override in subclasses to return a `dict[str, ComputedFeatureValue]`.
+- `ComputedFeatureValue` type alias (`int | float | str`).
+
+### Changed
+
+- `make_multiindex` now tracks index keys cumulatively to detect overlaps
+  between Pydantic fields, computed features, and `additional_index_data`.
+
+## [1.1.0] - 2026-03-28
 
 ### Added
 
@@ -39,4 +53,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deferred `hatchet` client import in `ScytheWorkerConfig.start()` to avoid
   import-time side effects.
 
-[1.1.0]: https://github.com/szvsw/scythe/compare/v1.0.0...HEAD
+[1.2.0]: https://github.com/szvsw/scythe/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/szvsw/scythe/compare/v1.0.0...v1.1.0

--- a/docs/concepts/experiment-lifecycle.md
+++ b/docs/concepts/experiment-lifecycle.md
@@ -22,7 +22,7 @@ flowchart TD
 
 You create two Pydantic models:
 
-- **`ExperimentInputSpec`** -- Defines the fields that parameterize each simulation run. These become the columns of the input DataFrame and the MultiIndex of the output DataFrames.
+- **`ExperimentInputSpec`** -- Defines the fields that parameterize each simulation run. These become the columns of the input DataFrame and the MultiIndex of the output DataFrames. Subclasses can also override `computed_features` to add derived index levels.
 - **`ExperimentOutputSpec`** -- Defines the scalar output fields and optional `FileReference` outputs. Scalar fields become columns of `scalars.pq`; file reference fields become columns of `result_file_refs.pq`.
 
 Both support `FileReference` fields (`S3Url | HttpUrl | pathlib.Path`) for handling file-based inputs and outputs.
@@ -82,7 +82,7 @@ Each leaf experiment task:
 2. Optionally replaces the `log` method with Hatchet's context logger
 3. Fetches remote file references to a local cache (or temp directory)
 4. Calls your simulation function
-5. Extracts scalar outputs into a DataFrame row with a MultiIndex from the input spec
+5. Extracts scalar outputs into a DataFrame row with a MultiIndex from the input spec fields and any `computed_features`
 6. Uploads any output `FileReference` files to S3 and records their URIs
 7. Uploads any additional DataFrames to S3
 8. Returns the serialized output spec

--- a/docs/guides/defining-experiments.md
+++ b/docs/guides/defining-experiments.md
@@ -35,7 +35,27 @@ You do not need to set these when creating specs -- they are populated automatic
 
 - `log(msg)` -- Log a message. During task execution, this is redirected to the Hatchet context logger so messages appear in the Hatchet dashboard.
 - `fetch_uri(uri, use_cache=True)` -- Fetch a file from S3, HTTP, or the local filesystem and return the local path. Results are cached by default.
-- `make_multiindex(n_rows=1, additional_index_data=None)` -- Construct a `pd.MultiIndex` from the spec fields, used for indexing output DataFrames.
+- `make_multiindex(n_rows=1, additional_index_data=None)` -- Construct a `pd.MultiIndex` from the spec fields (plus any `computed_features`), used for indexing output DataFrames.
+
+### Computed Features
+
+Sometimes you need extra index levels that are **derived** from existing fields rather than stored as their own Pydantic fields. Override the `computed_features` property to return a dictionary of scalar values that will be merged into the `MultiIndex` automatically:
+
+```python
+from pydantic import Field
+from scythe.base import ComputedFeatureValue, ExperimentInputSpec
+
+
+class MyInput(ExperimentInputSpec):
+    temperature: float = Field(..., description="Temperature [K]", ge=0)
+    pressure: float = Field(..., description="Pressure [Pa]", ge=0)
+
+    @property
+    def computed_features(self) -> dict[str, ComputedFeatureValue]:
+        return {"temp_bucket": "high" if self.temperature > 500 else "low"}
+```
+
+Computed feature keys must not overlap with Pydantic field names or any keys supplied via `additional_index_data`. Values must be `int`, `float`, or `str` (the `ComputedFeatureValue` type alias). In `make_multiindex`, computed features are inserted after the Pydantic field dump and before `additional_index_data`.
 
 ## Output Specs
 

--- a/docs/guides/retrieving-results.md
+++ b/docs/guides/retrieving-results.md
@@ -63,6 +63,8 @@ The primary output file. Its structure is:
 | 42.0   | 95.0       |
 | 38.5   | 91.2       |
 
+If your `ExperimentInputSpec` subclass overrides `computed_features`, those derived values also appear as additional index levels (between the Pydantic fields and any `additional_index_data`).
+
 Fields that cannot be represented in a pandas MultiIndex (e.g., `FileReference`, lists, dicts) are automatically excluded from the index.
 
 ### result_file_refs.pq

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -8,7 +8,7 @@ Core base classes for experiment input and output schemas.
 
 ::: scythe.base
 options:
-members: - BaseSpec - ExperimentInputSpec - ExperimentOutputSpec
+members: - BaseSpec - ExperimentInputSpec - ExperimentOutputSpec - ComputedFeatureValue
 show_root_heading: false
 
 ## scythe.registry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scythe-engine"
-version = "1.1.0"
+version = "1.2.0"
 description = "This is a repository for managing embarassingly parallel experiments with Hatchet."
 authors = [
     { name = "Sam Wolk", email = "mail@samwolk.info" }

--- a/src/scythe/base.py
+++ b/src/scythe/base.py
@@ -142,6 +142,9 @@ class ExperimentIndexAdditionalDataOverlapsWithSpecError(Exception):
         )
 
 
+ComputedFeatureValue = int | float | str
+
+
 # TODO: consider making the payload a generic?
 class ExperimentInputSpec(BaseSpec):
     """A spec for running a leaf workflow."""
@@ -157,6 +160,15 @@ class ExperimentInputSpec(BaseSpec):
         default=None, description="The storage settings to use."
     )
     _original_spec: "Self | None" = None
+
+    @property
+    def computed_features(self) -> dict[str, ComputedFeatureValue]:
+        """Scalar features merged into :meth:`make_multiindex` for combined result frames.
+
+        Override in subclasses to attach derived index levels (e.g. labels from other
+        fields). Keys must not overlap Pydantic fields included in the index dump.
+        """
+        return {}
 
     @property
     def prefix(self) -> str:
@@ -186,7 +198,7 @@ class ExperimentInputSpec(BaseSpec):
 
         return additional_excludes.union({"storage_settings", "_original_spec"})
 
-    def make_multiindex(
+    def make_multiindex(  # noqa: C901
         self,
         additional_index_data: dict[str, Any] | list[dict[str, Any]] | None = None,
         n_rows: int = 1,
@@ -215,15 +227,26 @@ class ExperimentInputSpec(BaseSpec):
             exclude=instance_to_dump._index_excluded_fields.union(additional_excludes),
         )
         index_data: list[dict[str, Any]] = [dumped_index for _ in range(n_rows)]
+        index_keys_so_far: set[str] = set(dumped_index)
+
+        cf = self.computed_features
+        if cf:
+            overlapping_cf = [k for k in cf if k in index_keys_so_far]
+            if overlapping_cf:
+                raise ExperimentIndexAdditionalDataOverlapsWithSpecError(overlapping_cf)
+            index_keys_so_far.update(cf)
+            for d in index_data:
+                d.update(cf)
 
         if isinstance(additional_index_data, dict):
-            if any(k in dumped_index for k in additional_index_data):
-                overlapping_keys = [
-                    k for k in additional_index_data if k in dumped_index
-                ]
+            overlapping_keys = [
+                k for k in additional_index_data if k in index_keys_so_far
+            ]
+            if overlapping_keys:
                 raise ExperimentIndexAdditionalDataOverlapsWithSpecError(
                     overlapping_keys
                 )
+            index_keys_so_far.update(additional_index_data)
             for d in index_data:
                 d.update(additional_index_data)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2652,7 +2652,7 @@ wheels = [
 
 [[package]]
 name = "scythe-engine"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `computed_features` property on `ExperimentInputSpec` that subclasses can override to supply extra scalar index levels (`str` keys; `int`, `float`, or `str` values). The base implementation returns `{}`.

`make_multiindex` merges these entries into the same row dicts used to build the `pandas.MultiIndex`, so any code path that indexes results with `input_spec.make_multiindex()`—including `_add_scalars` and `_transfer_files` in `ExperimentOutputSpec`—picks up the computed features when outputs are combined via `pd.concat`.

Overlapping keys between `computed_features`, the JSON model dump, and `additional_index_data` still raise `ExperimentIndexAdditionalDataOverlapsWithSpecError`.

## Testing

- `PYTHONPATH=src python3 -m pytest tests/ -q`
- Manual snippet verifying merged index level names and values for an overriding subclass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cda7c1f3-93ef-447f-9377-f135adc0f187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cda7c1f3-93ef-447f-9377-f135adc0f187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

