### PR TITLE
Add configurable scatter/gather collection depth with URI-reference fan-in

### DIFF
--- a/docs/concepts/scatter-gather.md
+++ b/docs/concepts/scatter-gather.md
@@ -57,6 +57,7 @@ recursion_map = RecursionMap(
 | ----------- | --------------------------------------------------------------------------------------------------- |
 | `factor`    | The branching factor -- how many children each scatter/gather node creates.                         |
 | `max_depth` | The maximum recursion depth. At depth 0, the root node runs experiments directly with no recursion. |
+| `collect_from_depth` | The minimum depth at which a node materializes child dataframes. Shallower nodes keep URI references only. Default `0` (collect all the way to root). |
 | `path`      | (Internal) Tracks the current position in the recursion tree. You do not set this directly.         |
 
 ### Base Case
@@ -65,6 +66,32 @@ A scatter/gather node reaches the base case and runs experiments directly when e
 
 - The number of remaining specs is less than or equal to `factor`
 - The current recursion depth has reached `max_depth`
+
+### Configurable Collection Depth
+
+By default, Scythe fully gathers to the root (`collect_from_depth=0`), materializing and concatenating DataFrames at every level.
+
+For very large runs, you can reduce gather-time memory pressure by setting `collect_from_depth` to a deeper level:
+
+- Nodes at depth **>= `collect_from_depth`** gather child DataFrames normally.
+- Nodes at depth **< `collect_from_depth`** avoid reading child parquet payloads and instead aggregate URI references.
+
+Example (`factor=3`, `max_depth=2`):
+
+- `collect_from_depth=0` (default): full gather to one final parquet per dataframe key.
+- `collect_from_depth=1`: root stores references to the 3 depth-1 outputs.
+- `collect_from_depth=2`: depth-0 and depth-1 nodes store references; root points to depth-2 terminal outputs.
+
+When collection is stopped above the root, the root still returns a usable result via a special reference dataframe key:
+
+- `_scythe_dataframe_references.pq`
+
+This dataframe includes two columns:
+
+- `dataframe_key` (e.g. `scalars`, `result_file_refs`, user dataframe names)
+- `uri` (S3 URI to the parquet file)
+
+This gives you a stable root artifact that can be traversed later (for selective downloads, Athena-driven querying, etc.) without forcing full in-memory recombination at upper levels.
 
 ### Choosing Parameters
 

--- a/docs/guides/running-experiments.md
+++ b/docs/guides/running-experiments.md
@@ -138,9 +138,22 @@ run, ref = experiment.allocate(
     version="bumpminor",
     recursion_map=RecursionMap(factor=100, max_depth=2),
 )
+
+# Keep full fan-out, but avoid materializing child frames at root depth
+run, ref = experiment.allocate(
+    specs,
+    version="bumpminor",
+    recursion_map=RecursionMap(factor=3, max_depth=2, collect_from_depth=1),
+)
 ```
 
 When `recursion_map` is not specified, the default is `RecursionMap(factor=10, max_depth=0)` (no recursion, factor ignored).
+
+`collect_from_depth` controls where fan-in begins:
+
+- Default `collect_from_depth=0`: full materialization to root (existing behavior)
+- `collect_from_depth=1`: root stores a reference dataframe (`_scythe_dataframe_references`) that lists child parquet URIs instead of loading/concatenating all child dataframes
+- Larger values delay dataframe materialization deeper into the tree and can reduce gather-memory pressure on upper levels
 
 !!! tip "Prefer `max_depth=1` with a high branching factor"
     [Benchmarks](https://github.com/szvsw/scythe-benchmark) show that the number of terminal nodes (`factor^max_depth`) is the dominant throughput driver. Using `max_depth=1` with a high factor (e.g. 32+) maximizes parallelism while keeping deadlock avoidance trivial (only one scatter/gather slot needed). Only increase `max_depth` if the required terminal scatter/gather-node count is so large that a single scatter/gather node at levels of the tree closer to the root would exceed Hatchet's batched enqueuing limit when enqueueing the next level of the tree. See [Scatter/Gather Concepts](../concepts/scatter-gather.md#choosing-parameters) for details.

--- a/src/scythe/scatter_gather.py
+++ b/src/scythe/scatter_gather.py
@@ -68,6 +68,16 @@ class RecursionMap(BaseModel):
     max_depth: int = Field(
         default=10, description="The maximum depth of the recursion", ge=0, le=10
     )
+    collect_from_depth: int = Field(
+        default=0,
+        description=(
+            "The minimum recursion depth at which nodes should materialize child "
+            "dataframes. Nodes shallower than this depth aggregate lightweight "
+            "URI references instead."
+        ),
+        ge=0,
+        le=10,
+    )
 
     @property
     def is_root(self) -> bool:
@@ -91,6 +101,10 @@ class GatheredExperimentRuns(BaseModel, arbitrary_types_allowed=True):
     # TODO: make success a little more extensible?
     success: ExperimentOutputSpec
     errors: pd.DataFrame | None
+
+
+SCYTHE_DATAFRAME_REFERENCES_KEY = "_scythe_dataframe_references"
+SCYTHE_DATAFRAME_REFERENCE_COLUMNS = ("dataframe_key", "uri")
 
 
 class ScatterGatherInput(BaseSpec):
@@ -219,6 +233,7 @@ class ScatterGatherInput(BaseSpec):
                 path=new_path,
                 factor=self.recursion_map.factor,
                 max_depth=self.recursion_map.max_depth,
+                collect_from_depth=self.recursion_map.collect_from_depth,
             )
             specs_to_use = specs[branch_ix :: self.recursion_map.factor]
             specs_as_df = pd.DataFrame([
@@ -280,6 +295,16 @@ class ScatterGatherInput(BaseSpec):
         ) or self.recursion_map.max_depth == 0
         return too_few_specs or past_max_depth
 
+    @property
+    def depth(self) -> int:
+        """Get the current depth within the recursion tree."""
+        return len(self.recursion_map.path or [])
+
+    @property
+    def should_materialize_collection(self) -> bool:
+        """Whether this node should fetch and combine child dataframes."""
+        return self.depth >= self.recursion_map.collect_from_depth
+
     async def run_or_recurse(
         self,
         ctx: Context,
@@ -287,7 +312,7 @@ class ScatterGatherInput(BaseSpec):
         """Run the experiments if not a base case, otherwise recurse."""
         self.add_root_workflow_run_id(ctx.workflow_run_id)
         n_specs = len(self.specs)
-        depth = len(self.recursion_map.path or [])
+        depth = self.depth
 
         if self.is_base_case:
             logger.info(
@@ -306,12 +331,22 @@ class ScatterGatherInput(BaseSpec):
             trigs, children_specs = self.create_recursion_payloads(ctx.workflow_run_id)
             results = await scatter_gather.aio_run_many(trigs, return_exceptions=True)
             safe_results, _error_df = sift_results(children_specs, results)
+            materialize_collection = self.should_materialize_collection
+            logger.info(
+                "Gather strategy at depth=%d: %s",
+                depth,
+                "materialize-dataframes"
+                if materialize_collection
+                else "references-only",
+            )
 
             def gather_experiment_outputs(
                 r: ScatterGatherResult,
             ) -> GatheredExperimentRuns | None:
                 try:
-                    return r.to_gathered_experiment_runs()
+                    if materialize_collection:
+                        return r.to_gathered_experiment_runs()
+                    return r.to_reference_gathered_experiment_runs()
                 except Exception:
                     logger.exception("Error gathering experiment outputs")
                     return None
@@ -328,6 +363,43 @@ class ScatterGatherResult(BaseModel):
     """The result of the scatter gather workflow."""
 
     uris: dict[str, S3Url]
+
+    @staticmethod
+    def _is_reference_dataframe(df: pd.DataFrame) -> bool:
+        """Check whether a dataframe has the expected reference schema."""
+        return set(SCYTHE_DATAFRAME_REFERENCE_COLUMNS).issubset(df.columns)
+
+    def _to_reference_dataframe_from_uris(self) -> pd.DataFrame:
+        """Convert URI mappings into a serializable reference dataframe."""
+        return pd.DataFrame(
+            [
+                {
+                    "dataframe_key": dataframe_key,
+                    "uri": str(uri),
+                }
+                for dataframe_key, uri in self.uris.items()
+            ],
+            columns=list(SCYTHE_DATAFRAME_REFERENCE_COLUMNS),
+        )
+
+    def _try_read_reference_dataframe(self, uri: S3Url) -> pd.DataFrame | None:
+        """Try reading an existing reference dataframe from a parquet URI."""
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                f = Path(tmpdir) / "scythe_dataframe_refs.parquet"
+                res_path = fetch_uri(uri=uri, local_path=f, use_cache=False)
+                df = pd.read_parquet(res_path)
+                if not self._is_reference_dataframe(df):
+                    logger.warning(
+                        "Reference parquet at %s missing required columns %s",
+                        uri,
+                        SCYTHE_DATAFRAME_REFERENCE_COLUMNS,
+                    )
+                    return None
+                return df.loc[:, list(SCYTHE_DATAFRAME_REFERENCE_COLUMNS)]
+        except Exception:
+            logger.exception("Failed to read reference dataframe from %s", uri)
+            return None
 
     def to_gathered_experiment_runs(self) -> GatheredExperimentRuns:
         """Convert the scatter gather result to a gathered experiment runs."""
@@ -357,6 +429,53 @@ class ScatterGatherResult(BaseModel):
         return GatheredExperimentRuns(
             success=ExperimentOutputSpec(
                 dataframes=dfs,
+            ),
+            errors=None,
+        )
+
+    def to_reference_gathered_experiment_runs(self) -> GatheredExperimentRuns:
+        """Convert the result to a URI reference dataframe.
+
+        If this result already points to a reference dataframe generated by a deeper
+        node, this method reads and forwards that dataframe so URI references remain
+        flattened across multiple non-materializing levels.
+        """
+        reference_uri = self.uris.get(SCYTHE_DATAFRAME_REFERENCES_KEY)
+        rows: list[dict[str, str]] = []
+        if reference_uri:
+            reference_df = self._try_read_reference_dataframe(reference_uri)
+            if reference_df is not None:
+                rows.extend(
+                    [
+                        {
+                            "dataframe_key": str(dataframe_key),
+                            "uri": str(uri),
+                        }
+                        for dataframe_key, uri in zip(
+                            reference_df["dataframe_key"],
+                            reference_df["uri"],
+                            strict=True,
+                        )
+                    ]
+                )
+        rows.extend(
+            [
+                {
+                    "dataframe_key": dataframe_key,
+                    "uri": str(uri),
+                }
+                for dataframe_key, uri in self.uris.items()
+                if dataframe_key != SCYTHE_DATAFRAME_REFERENCES_KEY
+            ]
+        )
+        reference_df = (
+            pd.DataFrame(rows, columns=list(SCYTHE_DATAFRAME_REFERENCE_COLUMNS))
+            if rows
+            else self._to_reference_dataframe_from_uris()
+        )
+        return GatheredExperimentRuns(
+            success=ExperimentOutputSpec(
+                dataframes={SCYTHE_DATAFRAME_REFERENCES_KEY: reference_df}
             ),
             errors=None,
         )

--- a/tests/test_scatter_gather_collect_depth.py
+++ b/tests/test_scatter_gather_collect_depth.py
@@ -1,0 +1,126 @@
+"""Tests for configurable scatter/gather collection depth behavior."""
+
+from pathlib import Path
+
+import pandas as pd
+
+from scythe.scatter_gather import (
+    SCYTHE_DATAFRAME_REFERENCES_KEY,
+    RecursionMap,
+    ScatterGatherResult,
+    ScatterGatherInput,
+)
+from scythe.settings import ScytheStorageSettings
+from scythe.utils.filesys import S3Url
+
+
+def _make_payload(recursion_map: RecursionMap) -> ScatterGatherInput:
+    """Build a minimal payload for property-level tests."""
+    return ScatterGatherInput(
+        experiment_id="exp/test",
+        task_name="does_not_matter_for_property_tests",
+        specs_uri=S3Url("s3://bucket/specs.pq"),
+        storage_settings=ScytheStorageSettings(BUCKET="bucket"),
+        recursion_map=recursion_map,
+    )
+
+
+def test_should_materialize_collection_respects_collect_from_depth() -> None:
+    """Nodes at or below collect_from_depth should materialize child dataframes."""
+    root_payload = _make_payload(
+        RecursionMap(path=None, factor=3, max_depth=2, collect_from_depth=1)
+    )
+    depth_one_payload = _make_payload(
+        RecursionMap(
+            path=[{"factor": 3, "offset": 0}],
+            factor=3,
+            max_depth=2,
+            collect_from_depth=1,
+        )
+    )
+
+    assert root_payload.depth == 0
+    assert root_payload.should_materialize_collection is False
+
+    assert depth_one_payload.depth == 1
+    assert depth_one_payload.should_materialize_collection is True
+
+
+def test_to_reference_gathered_experiment_runs_from_regular_uris() -> None:
+    """Reference gather converts URI mapping into a serializable dataframe."""
+    result = ScatterGatherResult(
+        uris={
+            "scalars": S3Url("s3://bucket/scalars.pq"),
+            "result_file_refs": S3Url("s3://bucket/result_file_refs.pq"),
+        }
+    )
+
+    gathered = result.to_reference_gathered_experiment_runs()
+    refs_df = gathered.success.dataframes[SCYTHE_DATAFRAME_REFERENCES_KEY]
+
+    expected = pd.DataFrame(
+        [
+            {"dataframe_key": "scalars", "uri": "s3://bucket/scalars.pq"},
+            {
+                "dataframe_key": "result_file_refs",
+                "uri": "s3://bucket/result_file_refs.pq",
+            },
+        ]
+    )
+    assert refs_df.reset_index(drop=True).equals(expected)
+
+
+def test_to_reference_gathered_experiment_runs_flattens_existing_reference_file(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """If the result already points to a reference parquet, it should be reused."""
+    existing_refs = pd.DataFrame(
+        [
+            {"dataframe_key": "scalars", "uri": "s3://bucket/inner_scalars.pq"},
+            {"dataframe_key": "metrics", "uri": "s3://bucket/inner_metrics.pq"},
+        ]
+    )
+
+    def fake_fetch_uri(uri: S3Url, local_path: Path, use_cache: bool = False) -> Path:
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        existing_refs.to_parquet(local_path)
+        return local_path
+
+    monkeypatch.setattr("scythe.scatter_gather.fetch_uri", fake_fetch_uri)
+
+    result = ScatterGatherResult(
+        uris={SCYTHE_DATAFRAME_REFERENCES_KEY: S3Url("s3://bucket/refs_only.pq")}
+    )
+    gathered = result.to_reference_gathered_experiment_runs()
+    refs_df = gathered.success.dataframes[SCYTHE_DATAFRAME_REFERENCES_KEY]
+
+    assert refs_df.reset_index(drop=True).equals(existing_refs)
+
+
+def test_to_reference_gathered_experiment_runs_falls_back_when_reference_unreadable(
+    monkeypatch,
+) -> None:
+    """Unreadable flattened reference URI should fall back to direct URI listing."""
+
+    def fake_fetch_uri(uri: S3Url, local_path: Path, use_cache: bool = False) -> Path:
+        msg = f"unable to fetch {uri}"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("scythe.scatter_gather.fetch_uri", fake_fetch_uri)
+
+    result = ScatterGatherResult(
+        uris={SCYTHE_DATAFRAME_REFERENCES_KEY: S3Url("s3://bucket/refs_only.pq")}
+    )
+    gathered = result.to_reference_gathered_experiment_runs()
+    refs_df = gathered.success.dataframes[SCYTHE_DATAFRAME_REFERENCES_KEY]
+
+    expected = pd.DataFrame(
+        [
+            {
+                "dataframe_key": SCYTHE_DATAFRAME_REFERENCES_KEY,
+                "uri": "s3://bucket/refs_only.pq",
+            }
+        ]
+    )
+    assert refs_df.reset_index(drop=True).equals(expected)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a configurable gather cutoff depth for recursive scatter/gather so upper levels can avoid materializing and concatenating large DataFrames.

### What changed

- Added `collect_from_depth` to `RecursionMap` (default `0`, preserving existing full collection behavior).
- Propagated `collect_from_depth` to child recursion payloads.
- Added depth-aware gather behavior in recursion fan-in:
  - Depths `>= collect_from_depth` keep current behavior (fetch/read child parquet DataFrames and combine).
  - Depths `< collect_from_depth` aggregate lightweight URI references instead of materialized DataFrames.
- Added a stable reference dataframe key:
  - `_scythe_dataframe_references`
  - Schema: `dataframe_key`, `uri`
- Added logic to flatten already-generated reference dataframes when possible, while gracefully falling back if reference parquet fetch/read fails.
- Added tests for:
  - depth gating (`should_materialize_collection`)
  - URI map -> reference dataframe conversion
  - flattening existing reference parquet
  - fallback behavior when flattened reference parquet is unreadable
- Updated docs in:
  - `docs/concepts/scatter-gather.md`
  - `docs/guides/running-experiments.md`

## Motivation

For very large datasets, full fan-in at every level can trigger memory pressure near the root. This change allows callers to stop materialized collection earlier while still returning a usable root artifact (a serialized URI manifest dataframe) for downstream selective retrieval/query workflows.

## Validation

- `python3 -m pytest -q`
  - `6 passed`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28da3eab-ab47-4cca-a1f5-dad782ac98cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28da3eab-ab47-4cca-a1f5-dad782ac98cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

